### PR TITLE
Add support to multiple clouds

### DIFF
--- a/workplace/provider.go
+++ b/workplace/provider.go
@@ -375,6 +375,9 @@ func (p *workplaceProvider) Configure(ctx context.Context, req provider.Configur
 	}
 
 	graphClient := msgraph.NewClient(msgraph.VersionBeta)
+	if ep, _ := env.MicrosoftGraph.Endpoint(); ep != nil && *ep != "" {
+		graphClient.Endpoint = *ep
+	}
 	graphClient.Authorizer = authorizer
 	graphClient.RequestMiddlewares = &[]msgraph.RequestMiddleware{requestLogger}
 	graphClient.ResponseMiddlewares = &[]msgraph.ResponseMiddleware{responseLogger}


### PR DESCRIPTION
Resolves #21 by setting the endpoints based on the environment which was passed in.

provider "microsoft365wp" {
  environment   = "usgovernment"
  tenant_id     = <tenant_id>
  client_id     = <client_id>
  client_secret = <client_secret>
}
Will make calls to graph.microsoft.us while
provider "microsoft365wp" {
  tenant_id     = <tenant_id>
  client_id     = <client_id>
  client_secret = <client_secret>
}
will still make calls to graph.microsoft.com